### PR TITLE
Update LSP, tree-sitter and fix spell highlight grups

### DIFF
--- a/lua/lush_theme/lush_template.lua
+++ b/lua/lush_theme/lush_template.lua
@@ -47,8 +47,8 @@ local hsl = lush.hsl
 
 local theme = lush(function()
   return {
-    -- The following are all the Neovim default highlight groups from
-    -- docs as of 0.5.0-812, to aid your theme creation. Your themes should
+    -- The following are all the Neovim default highlight groups from the docs
+    -- as of 0.5.0-nightly-446, to aid your theme creation. Your themes should
     -- probably style all of these at a bare minimum.
     --
     -- Referenced/linked groups must come before being referenced/lined,

--- a/lua/lush_theme/lush_template.lua
+++ b/lua/lush_theme/lush_template.lua
@@ -204,50 +204,58 @@ local theme = lush(function()
     -- TSError -> Error for example, so you do not have to define these unless
     -- you explicitly want to support Treesitter's improved syntax awareness.
 
-    -- TSError              { }, -- For syntax/parser errors.
-    -- TSPunctDelimiter     { }, -- For delimiters ie: `.`
-    -- TSPunctBracket       { }, -- For brackets and parens.
-    -- TSPunctSpecial       { }, -- For special punctutation that does not fall in the catagories before.
-    -- TSConstant           { }, -- For constants
-    -- TSConstBuiltin       { }, -- For constant that are built in the language: `nil` in Lua.
-    -- TSConstMacro         { }, -- For constants that are defined by macros: `NULL` in C.
-    -- TSString             { }, -- For strings.
-    -- TSStringRegex        { }, -- For regexes.
-    -- TSStringEscape       { }, -- For escape characters within a string.
-    -- TSCharacter          { }, -- For characters.
-    -- TSNumber             { }, -- For integers.
-    -- TSBoolean            { }, -- For booleans.
-    -- TSFloat              { }, -- For floats.
-    -- TSFunction           { }, -- For function (calls and definitions).
-    -- TSFuncBuiltin        { }, -- For builtin functions: `table.insert` in Lua.
-    -- TSFuncMacro          { }, -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
-    -- TSParameter          { }, -- For parameters of a function.
-    -- TSParameterReference { }, -- For references to parameters of a function.
-    -- TSMethod             { }, -- For method calls and definitions.
-    -- TSField              { }, -- For fields.
-    -- TSProperty           { }, -- Same as `TSField`.
-    -- TSConstructor        { }, -- For constructor calls and definitions: `{ }` in Lua, and Java constructors.
-    -- TSConditional        { }, -- For keywords related to conditionnals.
-    -- TSRepeat             { }, -- For keywords related to loops.
-    -- TSLabel              { }, -- For labels: `label:` in C and `:label:` in Lua.
-    -- TSOperator           { }, -- For any operator: `+`, but also `->` and `*` in C.
-    -- TSKeyword            { }, -- For keywords that don't fall in previous categories.
-    -- TSKeywordFunction    { }, -- For keywords used to define a fuction.
-    -- TSException          { }, -- For exception related keywords.
-    -- TSType               { }, -- For types.
-    -- TSTypeBuiltin        { }, -- For builtin types (you guessed it, right ?).
-    -- TSNamespace          { }, -- For identifiers referring to modules and namespaces.
-    -- TSInclude            { }, -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
-    -- TSAnnotation         { }, -- For C++/Dart attributes, annotations that can be attached to the code to denote some kind of meta information.
-    -- TSText               { }, -- For strings considered text in a markup language.
-    -- TSStrong             { }, -- For text to be represented with strong.
-    -- TSEmphasis           { }, -- For text to be represented with emphasis.
-    -- TSUnderline          { }, -- For text to be represented with an underline.
-    -- TSTitle              { }, -- Text that is part of a title.
-    -- TSLiteral            { }, -- Literal text.
-    -- TSURI                { }, -- Any URI like a link or email.
-    -- TSVariable           { }, -- Any variable name that does not have another highlight.
-    -- TSVariableBuiltin    { }, -- Variable names that are defined by the languages, like `this` or `self`.
+    -- TSAnnotation         { };    -- For C++/Dart attributes, annotations that can be attached to the code to denote some kind of meta information.
+    -- TSAttribute          { };    -- (unstable) TODO: docs
+    -- TSBoolean            { };    -- For booleans.
+    -- TSCharacter          { };    -- For characters.
+    -- TSComment            { };    -- For comment blocks.
+    -- TSConstructor        { };    -- For constructor calls and definitions: ` { }` in Lua, and Java constructors.
+    -- TSConditional        { };    -- For keywords related to conditionnals.
+    -- TSConstant           { };    -- For constants
+    -- TSConstBuiltin       { };    -- For constant that are built in the language: `nil` in Lua.
+    -- TSConstMacro         { };    -- For constants that are defined by macros: `NULL` in C.
+    -- TSError              { };    -- For syntax/parser errors.
+    -- TSException          { };    -- For exception related keywords.
+    -- TSField              { };    -- For fields.
+    -- TSFloat              { };    -- For floats.
+    -- TSFunction           { };    -- For function (calls and definitions).
+    -- TSFuncBuiltin        { };    -- For builtin functions: `table.insert` in Lua.
+    -- TSFuncMacro          { };    -- For macro defined fuctions (calls and definitions): each `macro_rules` in Rust.
+    -- TSInclude            { };    -- For includes: `#include` in C, `use` or `extern crate` in Rust, or `require` in Lua.
+    -- TSKeyword            { };    -- For keywords that don't fall in previous categories.
+    -- TSKeywordFunction    { };    -- For keywords used to define a fuction.
+    -- TSLabel              { };    -- For labels: `label:` in C and `:label:` in Lua.
+    -- TSMethod             { };    -- For method calls and definitions.
+    -- TSNamespace          { };    -- For identifiers referring to modules and namespaces.
+    -- TSNone               { };    -- TODO: docs
+    -- TSNumber             { };    -- For all numbers
+    -- TSOperator           { };    -- For any operator: `+`, but also `->` and `*` in C.
+    -- TSParameter          { };    -- For parameters of a function.
+    -- TSParameterReference { };    -- For references to parameters of a function.
+    -- TSProperty           { };    -- Same as `TSField`.
+    -- TSPunctDelimiter     { };    -- For delimiters ie: `.`
+    -- TSPunctBracket       { };    -- For brackets and parens.
+    -- TSPunctSpecial       { };    -- For special punctutation that does not fall in the catagories before.
+    -- TSRepeat             { };    -- For keywords related to loops.
+    -- TSString             { };    -- For strings.
+    -- TSStringRegex        { };    -- For regexes.
+    -- TSStringEscape       { };    -- For escape characters within a string.
+    -- TSSymbol             { };    -- For identifiers referring to symbols or atoms.
+    -- TSType               { };    -- For types.
+    -- TSTypeBuiltin        { };    -- For builtin types.
+    -- TSVariable           { };    -- Any variable name that does not have another highlight.
+    -- TSVariableBuiltin    { };    -- Variable names that are defined by the languages, like `this` or `self`.
+
+    -- TSTag                { };    -- Tags like html tag names.
+    -- TSTagDelimiter       { };    -- Tag delimiter like `<` `>` `/`
+    -- TSText               { };    -- For strings considered text in a markup language.
+    -- TSEmphasis           { };    -- For text to be represented with emphasis.
+    -- TSUnderline          { };    -- For text to be represented with an underline.
+    -- TSStrike             { };    -- For strikethrough text.
+    -- TSTitle              { };    -- Text that is part of a title.
+    -- TSLiteral            { };    -- Literal text.
+    -- TSURI                { };    -- Any URI like a link or email.
+
   }
 end)
 

--- a/lua/lush_theme/lush_template.lua
+++ b/lua/lush_theme/lush_template.lua
@@ -99,7 +99,10 @@ local theme = lush(function()
     -- Question     { }, -- |hit-enter| prompt and yes/no questions
     -- QuickFixLine { }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
     -- Search       { }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
-    -- SpecialKey   { }, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace| SpellBad  Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.  SpellCap  Word that should start with a capital. |spell| Combined with the highlighting used otherwise.  SpellLocal  Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
+    -- SpecialKey   { }, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
+    -- SpellBad     { }, -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise. 
+    -- SpellCap     { }, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
+    -- SpellLocal   { }, -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
     -- SpellRare    { }, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
     -- StatusLine   { }, -- status line of current window
     -- StatusLineNC { }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.

--- a/lua/lush_theme/lush_template.lua
+++ b/lua/lush_theme/lush_template.lua
@@ -166,24 +166,34 @@ local theme = lush(function()
 
     -- Todo           { }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
 
-    -- These groups are for the native LSP client. Some other LSP clients may use
-    -- these groups, or use their own. Consult your LSP client's documentation.
+    ---- These groups are for the native LSP client. Some other LSP clients may use
+    ---- these groups, or use their own. Consult your LSP client's documentation.
 
-    -- LspDiagnosticsError               { }, -- used for "Error" diagnostic virtual text
-    -- LspDiagnosticsErrorSign           { }, -- used for "Error" diagnostic signs in sign column
-    -- LspDiagnosticsErrorFloating       { }, -- used for "Error" diagnostic messages in the diagnostics float
-    -- LspDiagnosticsWarning             { }, -- used for "Warning" diagnostic virtual text
-    -- LspDiagnosticsWarningSign         { }, -- used for "Warning" diagnostic signs in sign column
-    -- LspDiagnosticsWarningFloating     { }, -- used for "Warning" diagnostic messages in the diagnostics float
-    -- LspDiagnosticsInformation         { }, -- used for "Information" diagnostic virtual text
-    -- LspDiagnosticsInformationSign     { }, -- used for "Information" signs in sign column
-    -- LspDiagnosticsInformationFloating { }, -- used for "Information" diagnostic messages in the diagnostics float
-    -- LspDiagnosticsHint                { }, -- used for "Hint" diagnostic virtual text
-    -- LspDiagnosticsHintSign            { }, -- used for "Hint" diagnostic signs in sign column
-    -- LspDiagnosticsHintFloating        { }, -- used for "Hint" diagnostic messages in the diagnostics float
-    -- LspReferenceText                  { }, -- used for highlighting "text" references
-    -- LspReferenceRead                  { }, -- used for highlighting "read" references
-    -- LspReferenceWrite                 { }, -- used for highlighting "write" references
+    -- LspReferenceText  { };    -- used for highlighting "text" references
+    -- LspReferenceRead  { };    -- used for highlighting "read" references
+    -- LspReferenceWrite { };    -- used for highlighting "write" references
+
+    -- LspDiagnosticsDefaultError       { };    --  Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    -- LspDiagnosticsDefaultWarning     { };    --  Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    -- LspDiagnosticsDefaultInformation { };    --  Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+    -- LspDiagnosticsDefaultHint        { };    --  Used as the base highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
+
+    -- LspDiagnosticsVirtualTextError       { };    --  Used for "Error" diagnostic virtual text
+    -- LspDiagnosticsVirtualTextWarning     { };    --  Used for "Warning" diagnostic virtual text
+    -- LspDiagnosticsVirtualTextInformation { };    --  Used for "Information" diagnostic virtual text
+    -- LspDiagnosticsVirtualTextHint        { };    --  Used for "Hint" diagnostic virtual text
+    -- LspDiagnosticsUnderlineError         { };    --  Used to underline "Error" diagnostics
+    -- LspDiagnosticsUnderlineWarning       { };    --  Used to underline "Warning" diagnostics
+    -- LspDiagnosticsUnderlineInformation   { };    --  Used to underline "Information" diagnostics
+    -- LspDiagnosticsUnderlineHint          { };    --  Used to underline "Hint" diagnostics
+    -- LspDiagnosticsFloatingError          { };    --  Used to color "Error" diagnostic messages in diagnostics float
+    -- LspDiagnosticsFloatingWarning        { };    --  Used to color "Warning" diagnostic messages in diagnostics float
+    -- LspDiagnosticsFloatingInformation    { };    --  Used to color "Information" diagnostic messages in diagnostics float
+    -- LspDiagnosticsFloatingHint           { };    --  Used to color "Hint" diagnostic messages in diagnostics float
+    -- LspDiagnosticsSignError              { };    --  Used for "Error" signs in sign column
+    -- LspDiagnosticsSignWarning            { };    --  Used for "Warning" signs in sign column
+    -- LspDiagnosticsSignInformation        { };    --  Used for "Information" signs in sign column
+    -- LspDiagnosticsSignHint               { };    --  Used for "Hint" signs in sign column
 
     -- These groups are for the neovim tree-sitter highlights.
     -- As of writing, tree-sitter support is a WIP, group names may change.


### PR DESCRIPTION
- Update LSP highlight groups (same changes as in the main repo)

- Update nvim-treesitter highlight groups. There are ~7 new groups (I changed the order to match the docs but the old order might be more useful, maybe change that)

- Update the listed version 😁 