### PR TITLE
Some cleanup; Add new Tree-Sitter groups

### DIFF
--- a/lua/lush_theme/lush_template.lua
+++ b/lua/lush_theme/lush_template.lua
@@ -17,7 +17,7 @@
 -- for usage guides, see :h lush or :LushRunTutorial
 
 --
--- Note: Because this is lua file, vim will append your file to the runtime,
+-- Note: Because this is a lua file, vim will append it to the runtime,
 --       which means you can require(...) it in other lua code (this is useful),
 --       but you should also take care not to conflict with other libraries.
 --
@@ -50,128 +50,124 @@ local hsl = lush.hsl
 ---@diagnostic disable: undefined-global
 local theme = lush(function()
   return {
-    -- The following are all the Neovim default highlight groups from the docs
-    -- as of 0.5.0-nightly-446, to aid your theme creation. Your themes should
-    -- probably style all of these at a bare minimum.
+    -- The following are the Neovim (as of 0.8.0-dev+100-g371dfb174) highlight
+    -- groups, mostly used for styling UI elements.
+    -- Comment them out and add your own properties to override the defaults.
+    -- An empty definition `{}` will clear all styling, leaving elements looking
+    -- like the 'Normal' group.
+    -- To be able to link to a group, it must already be defined, so you may have
+    -- to reorder items as you go.
     --
-    -- Referenced/linked groups must come before being referenced/lined,
-    -- so the order shown ((mostly) alphabetical) is likely
-    -- not the order you will end up with.
+    -- See :h highlight-groups
     --
-    -- You can uncomment these and leave them empty to disable any
-    -- styling for that group (meaning they mostly get styled as Normal)
-    -- or leave them commented to apply vims default colouring or linking.
-
-    -- Comment      { }, -- any comment
-    -- ColorColumn  { }, -- used for the columns set with 'colorcolumn'
-    -- Conceal      { }, -- placeholder characters substituted for concealed text (see 'conceallevel')
-    -- Cursor       { }, -- character under the cursor
-    -- lCursor      { }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
-    -- CursorIM     { }, -- like Cursor, but used when in IME mode |CursorIM|
+    -- ColorColumn  { }, -- Columns set with 'colorcolumn'
+    -- Conceal      { }, -- Placeholder characters substituted for concealed text (see 'conceallevel')
+    -- Cursor       { }, -- Character under the cursor
+    -- lCursor      { }, -- Character under the cursor when |language-mapping| is used (see 'guicursor')
+    -- CursorIM     { }, -- Like Cursor, but used when in IME mode |CursorIM|
     -- CursorColumn { }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
-    -- CursorLine   { }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
-    -- Directory    { }, -- directory names (and other special names in listings)
-    -- DiffAdd      { }, -- diff mode: Added line |diff.txt|
-    -- DiffChange   { }, -- diff mode: Changed line |diff.txt|
-    -- DiffDelete   { }, -- diff mode: Deleted line |diff.txt|
-    -- DiffText     { }, -- diff mode: Changed text within a changed line |diff.txt|
-    -- EndOfBuffer  { }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
-    -- TermCursor   { }, -- cursor in a focused terminal
-    -- TermCursorNC { }, -- cursor in an unfocused terminal
-    -- ErrorMsg     { }, -- error messages on the command line
-    -- VertSplit    { }, -- the column separating vertically split windows
-    -- Folded       { }, -- line used for closed folds
+    -- CursorLine   { }, -- Screen-line at the cursor, when 'cursorline' is set. Low-priority if foreground (ctermfg OR guifg) is not set.
+    -- Directory    { }, -- Directory names (and other special names in listings)
+    -- DiffAdd      { }, -- Diff mode: Added line |diff.txt|
+    -- DiffChange   { }, -- Diff mode: Changed line |diff.txt|
+    -- DiffDelete   { }, -- Diff mode: Deleted line |diff.txt|
+    -- DiffText     { }, -- Diff mode: Changed text within a changed line |diff.txt|
+    -- EndOfBuffer  { }, -- Filler lines (~) after the end of the buffer. By default, this is highlighted like |hl-NonText|.
+    -- TermCursor   { }, -- Cursor in a focused terminal
+    -- TermCursorNC { }, -- Cursor in an unfocused terminal
+    -- ErrorMsg     { }, -- Error messages on the command line
+    -- VertSplit    { }, -- Column separating vertically split windows
+    -- Folded       { }, -- Line used for closed folds
     -- FoldColumn   { }, -- 'foldcolumn'
-    -- SignColumn   { }, -- column where |signs| are displayed
+    -- SignColumn   { }, -- Column where |signs| are displayed
     -- IncSearch    { }, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
     -- Substitute   { }, -- |:substitute| replacement text highlighting
     -- LineNr       { }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
     -- CursorLineNr { }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
-    -- MatchParen   { }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
+    -- MatchParen   { }, -- Character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     -- ModeMsg      { }, -- 'showmode' message (e.g., "-- INSERT -- ")
     -- MsgArea      { }, -- Area for messages and cmdline
     -- MsgSeparator { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
     -- MoreMsg      { }, -- |more-prompt|
     -- NonText      { }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
-    -- Normal       { }, -- normal text
+    -- Normal       { }, -- Normal text
     -- NormalFloat  { }, -- Normal text in floating windows.
     -- NormalNC     { }, -- normal text in non-current windows
-    -- Pmenu        { }, -- Popup menu: normal item.
-    -- PmenuSel     { }, -- Popup menu: selected item.
-    -- PmenuSbar    { }, -- Popup menu: scrollbar.
+    -- Pmenu        { }, -- Popup menu: Normal item.
+    -- PmenuSel     { }, -- Popup menu: Selected item.
+    -- PmenuSbar    { }, -- Popup menu: Scrollbar.
     -- PmenuThumb   { }, -- Popup menu: Thumb of the scrollbar.
     -- Question     { }, -- |hit-enter| prompt and yes/no questions
     -- QuickFixLine { }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
-    -- Search       { }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
-    -- SpecialKey   { }, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
-    -- SpellBad     { }, -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise. 
+    -- Search       { }, -- Last search pattern highlighting (see 'hlsearch'). Also used for similar items that need to stand out.
+    -- SpecialKey   { }, -- Unprintable characters: text displayed differently from what it really is. But not 'listchars' whitespace. |hl-Whitespace|
+    -- SpellBad     { }, -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.
     -- SpellCap     { }, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
     -- SpellLocal   { }, -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
-    -- SpellRare    { }, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
-    -- StatusLine   { }, -- status line of current window
-    -- StatusLineNC { }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
-    -- TabLine      { }, -- tab pages line, not active tab page label
-    -- TabLineFill  { }, -- tab pages line, where there are no labels
-    -- TabLineSel   { }, -- tab pages line, active tab page label
-    -- Title        { }, -- titles for output from ":set all", ":autocmd" etc.
+    -- SpellRare    { }, -- Word that is recognized by the spellchecker as one that is hardly ever used. |spell| Combined with the highlighting used otherwise.
+    -- StatusLine   { }, -- Status line of current window
+    -- StatusLineNC { }, -- Status lines of not-current windows. Note: If this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
+    -- TabLine      { }, -- Tab pages line, not active tab page label
+    -- TabLineFill  { }, -- Tab pages line, where there are no labels
+    -- TabLineSel   { }, -- Tab pages line, active tab page label
+    -- Title        { }, -- Titles for output from ":set all", ":autocmd" etc.
     -- Visual       { }, -- Visual mode selection
     -- VisualNOS    { }, -- Visual mode selection when vim is "Not Owning the Selection".
-    -- WarningMsg   { }, -- warning messages
+    -- WarningMsg   { }, -- Warning messages
     -- Whitespace   { }, -- "nbsp", "space", "tab" and "trail" in 'listchars'
-    -- WildMenu     { }, -- current match in 'wildmenu' completion
+    -- Winseparator { }, -- Separator between window splits. Inherts from |hl-VertSplit| by default, which it will replace eventually.
+    -- WildMenu     { }, -- Current match in 'wildmenu' completion
 
-    -- These groups are not listed as default vim groups,
-    -- but they are defacto standard group names for syntax highlighting.
-    -- commented out groups should chain up to their "preferred" group by
-    -- default,
+    -- Common vim syntax groups used for all kinds of code and markup.
+    -- Commented-out groups should chain up to their preferred (*) group
+    -- by default.
+    --
+    -- See :h group-name
+    --
     -- Uncomment and edit if you want more specific syntax highlighting.
 
-    -- Constant       { }, -- (preferred) any constant
-    -- String         { }, --   a string constant: "this is a string"
-    -- Character      { }, --  a character constant: 'c', '\n'
-    -- Number         { }, --   a number constant: 234, 0xff
-    -- Boolean        { }, --  a boolean constant: TRUE, false
-    -- Float          { }, --    a floating point constant: 2.3e10
+    -- Comment        { }, -- Any comment
 
-    -- Identifier     { }, -- (preferred) any variable name
-    -- Function       { }, -- function name (also: methods for classes)
+    -- Constant       { }, -- (*) Any constant
+    -- String         { }, --   A string constant: "this is a string"
+    -- Character      { }, --   A character constant: 'c', '\n'
+    -- Number         { }, --   A number constant: 234, 0xff
+    -- Boolean        { }, --   A boolean constant: TRUE, false
+    -- Float          { }, --   A floating point constant: 2.3e10
 
-    -- Statement      { }, -- (preferred) any statement
-    -- Conditional    { }, --  if, then, else, endif, switch, etc.
+    -- Identifier     { }, -- (*) Any variable name
+    -- Function       { }, --   Function name (also: methods for classes)
+
+    -- Statement      { }, -- (*) Any statement
+    -- Conditional    { }, --   if, then, else, endif, switch, etc.
     -- Repeat         { }, --   for, do, while, etc.
-    -- Label          { }, --    case, default, etc.
-    -- Operator       { }, -- "sizeof", "+", "*", etc.
-    -- Keyword        { }, --  any other keyword
-    -- Exception      { }, --  try, catch, throw
+    -- Label          { }, --   case, default, etc.
+    -- Operator       { }, --   "sizeof", "+", "*", etc.
+    -- Keyword        { }, --   any other keyword
+    -- Exception      { }, --   try, catch, throw
 
-    -- PreProc        { }, -- (preferred) generic Preprocessor
-    -- Include        { }, --  preprocessor #include
-    -- Define         { }, --   preprocessor #define
-    -- Macro          { }, --    same as Define
-    -- PreCondit      { }, --  preprocessor #if, #else, #endif, etc.
+    -- PreProc        { }, -- (*) Generic Preprocessor
+    -- Include        { }, --   Preprocessor #include
+    -- Define         { }, --   Preprocessor #define
+    -- Macro          { }, --   Same as Define
+    -- PreCondit      { }, --   Preprocessor #if, #else, #endif, etc.
 
-    -- Type           { }, -- (preferred) int, long, char, etc.
-    -- StorageClass   { }, -- static, register, volatile, etc.
-    -- Structure      { }, --  struct, union, enum, etc.
-    -- Typedef        { }, --  A typedef
+    -- Type           { }, -- (*) int, long, char, etc.
+    -- StorageClass   { }, --   static, register, volatile, etc.
+    -- Structure      { }, --   struct, union, enum, etc.
+    -- Typedef        { }, --   A typedef
 
-    -- Special        { }, -- (preferred) any special symbol
-    -- SpecialChar    { }, --  special character in a constant
-    -- Tag            { }, --    you can use CTRL-] on this
-    -- Delimiter      { }, --  character that needs attention
-    -- SpecialComment { }, -- special things inside a comment
-    -- Debug          { }, --    debugging statements
+    -- Special        { }, -- (*) Any special symbol
+    -- SpecialChar    { }, --   Special character in a constant
+    -- Tag            { }, --   You can use CTRL-] on this
+    -- Delimiter      { }, --   Character that needs attention
+    -- SpecialComment { }, --   Special things inside a comment (e.g. '\n')
+    -- Debug          { }, --   Debugging statements
 
-    -- Underlined { gui = "underline" }, -- (preferred) text that stands out, HTML links
-    -- Bold       { gui = "bold" },
-    -- Italic     { gui = "italic" },
-
-    -- ("Ignore", below, may be invisible...)
-    -- Ignore         { }, -- (preferred) left blank, hidden  |hl-Ignore|
-
-    -- Error          { }, -- (preferred) any erroneous construct
-
-    -- Todo           { }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+    -- Underlined     { gui = "underline" }, -- Text that stands out, HTML links
+    -- Ignore         { }, -- Left blank, hidden |hl-Ignore| (NOTE: May be invisible here in template)
+    -- Error          { }, -- Any erroneous construct
+    -- Todo           { }, -- Anything that needs extra attention; mostly the keywords TODO FIXME and XXX
 
     -- These groups are for the native LSP client and diagnostic system. Some
     -- other LSP clients may use these groups, or use their own. Consult your
@@ -179,9 +175,9 @@ local theme = lush(function()
 
     -- See :h lsp-highlight, some groups may not be listed, submit a PR fix to lush-template!
     --
-    -- LspReferenceText            { } , -- used for highlighting "text" references
-    -- LspReferenceRead            { } , -- used for highlighting "read" references
-    -- LspReferenceWrite           { } , -- used for highlighting "write" references
+    -- LspReferenceText            { } , -- Used for highlighting "text" references
+    -- LspReferenceRead            { } , -- Used for highlighting "read" references
+    -- LspReferenceWrite           { } , -- Used for highlighting "write" references
     -- LspCodeLens                 { } , -- Used to color the virtual text of the codelens. See |nvim_buf_set_extmark()|.
     -- LspCodeLensSeparator        { } , -- Used to color the seperator between two or more code lens.
     -- LspSignatureActiveParameter { } , -- Used to highlight the active parameter in the signature help. See |vim.lsp.handlers.signature_help()|.
@@ -209,17 +205,23 @@ local theme = lush(function()
     -- DiagnosticSignInfo         { } , -- Used for "Info" signs in sign column.
     -- DiagnosticSignHint         { } , -- Used for "Hint" signs in sign column.
 
+    -- Tree-Sitter syntax groups. Most link to corresponding
+    -- vim syntax groups (e.g. TSKeyword => Keyword) by default.
+    --
     -- See :h nvim-treesitter-highlights, some groups may not be listed, submit a PR fix to lush-template!
     --
     -- TSAttribute          { } , -- Annotations that can be attached to the code to denote some kind of meta information. e.g. C++/Dart attributes.
     -- TSBoolean            { } , -- Boolean literals: `True` and `False` in Python.
     -- TSCharacter          { } , -- Character literals: `'a'` in C.
+    -- TSCharacterSpecial   { } , -- Special characters.
     -- TSComment            { } , -- Line comments and block comments.
     -- TSConditional        { } , -- Keywords related to conditionals: `if`, `when`, `cond`, etc.
     -- TSConstant           { } , -- Constants identifiers. These might not be semantically constant. E.g. uppercase variables in Python.
     -- TSConstBuiltin       { } , -- Built-in constant values: `nil` in Lua.
     -- TSConstMacro         { } , -- Constants defined by macros: `NULL` in C.
     -- TSConstructor        { } , -- Constructor calls and definitions: `{}` in Lua, and Java constructors.
+    -- TSDebug              { } , -- Debugging statements.
+    -- TSDefine             { } , -- Preprocessor #define statements.
     -- TSError              { } , -- Syntax/parser errors. This might highlight large sections of code while the user is typing still incomplete code, use a sensible highlight.
     -- TSException          { } , -- Exception related keywords: `try`, `except`, `finally` in Python.
     -- TSField              { } , -- Object and struct fields.
@@ -240,11 +242,13 @@ local theme = lush(function()
     -- TSOperator           { } , -- Binary or unary operators: `+`, and also `->` and `*` in C.
     -- TSParameter          { } , -- Parameters of a function.
     -- TSParameterReference { } , -- References to parameters of a function.
+    -- TSPreProc            { } , -- Preprocessor #if, #else, #endif, etc.
     -- TSProperty           { } , -- Same as `TSField`.
     -- TSPunctDelimiter     { } , -- Punctuation delimiters: Periods, commas, semicolons, etc.
     -- TSPunctBracket       { } , -- Brackets, braces, parentheses, etc.
     -- TSPunctSpecial       { } , -- Special punctuation that doesn't fit into the previous categories.
     -- TSRepeat             { } , -- Keywords related to loops: `for`, `while`, etc.
+    -- TSStorageClass       { } , -- Keywords that affect how a variable is stored: `static`, `comptime`, `extern`, etc.
     -- TSString             { } , -- String literals.
     -- TSStringRegex        { } , -- Regular expression literals.
     -- TSStringEscape       { } , -- Escape characters within a string: `\n`, `\t`, etc.
@@ -275,7 +279,7 @@ local theme = lush(function()
   }
 end)
 
--- return our parsed theme for extension or use else where.
+-- Return our parsed theme for extension or use elsewhere.
 return theme
 
 -- vi:nowrap


### PR DESCRIPTION
I'll send a PR to vim to fix the inconsistent capitalization in the docs. I made the vim syntax groups sound less "optional" — they're at the heart of what makes a colorscheme, so creators will always want to set them.