### PR TITLE
Update to nvim >= 0.8.0: Remove TS* and use @x.y groups instead

### DIFF
--- a/lua/lush_theme/lush_template.lua
+++ b/lua/lush_theme/lush_template.lua
@@ -48,7 +48,8 @@ local hsl = lush.hsl
 -- LSP/Linters mistakenly show `undefined global` errors in the spec, they may
 -- support an annotation like the following. Consult your server documentation.
 ---@diagnostic disable: undefined-global
-local theme = lush(function()
+local theme = lush(function(injected_functions)
+  local sym = injected_functions.sym
   return {
     -- The following are the Neovim (as of 0.8.0-dev+100-g371dfb174) highlight
     -- groups, mostly used for styling UI elements.
@@ -205,78 +206,57 @@ local theme = lush(function()
     -- DiagnosticSignInfo         { } , -- Used for "Info" signs in sign column.
     -- DiagnosticSignHint         { } , -- Used for "Hint" signs in sign column.
 
-    -- Tree-Sitter syntax groups. Most link to corresponding
-    -- vim syntax groups (e.g. TSKeyword => Keyword) by default.
+    -- Tree-Sitter syntax groups.
     --
-    -- See :h nvim-treesitter-highlights, some groups may not be listed, submit a PR fix to lush-template!
-    --
-    -- TSAttribute          { } , -- Annotations that can be attached to the code to denote some kind of meta information. e.g. C++/Dart attributes.
-    -- TSBoolean            { } , -- Boolean literals: `True` and `False` in Python.
-    -- TSCharacter          { } , -- Character literals: `'a'` in C.
-    -- TSCharacterSpecial   { } , -- Special characters.
-    -- TSComment            { } , -- Line comments and block comments.
-    -- TSConditional        { } , -- Keywords related to conditionals: `if`, `when`, `cond`, etc.
-    -- TSConstant           { } , -- Constants identifiers. These might not be semantically constant. E.g. uppercase variables in Python.
-    -- TSConstBuiltin       { } , -- Built-in constant values: `nil` in Lua.
-    -- TSConstMacro         { } , -- Constants defined by macros: `NULL` in C.
-    -- TSConstructor        { } , -- Constructor calls and definitions: `{}` in Lua, and Java constructors.
-    -- TSDebug              { } , -- Debugging statements.
-    -- TSDefine             { } , -- Preprocessor #define statements.
-    -- TSError              { } , -- Syntax/parser errors. This might highlight large sections of code while the user is typing still incomplete code, use a sensible highlight.
-    -- TSException          { } , -- Exception related keywords: `try`, `except`, `finally` in Python.
-    -- TSField              { } , -- Object and struct fields.
-    -- TSFloat              { } , -- Floating-point number literals.
-    -- TSFunction           { } , -- Function calls and definitions.
-    -- TSFuncBuiltin        { } , -- Built-in functions: `print` in Lua.
-    -- TSFuncMacro          { } , -- Macro defined functions (calls and definitions): each `macro_rules` in Rust.
-    -- TSInclude            { } , -- File or module inclusion keywords: `#include` in C, `use` or `extern crate` in Rust.
-    -- TSKeyword            { } , -- Keywords that don't fit into other categories.
-    -- TSKeywordFunction    { } , -- Keywords used to define a function: `function` in Lua, `def` and `lambda` in Python.
-    -- TSKeywordOperator    { } , -- Unary and binary operators that are English words: `and`, `or` in Python; `sizeof` in C.
-    -- TSKeywordReturn      { } , -- Keywords like `return` and `yield`.
-    -- TSLabel              { } , -- GOTO labels: `label:` in C, and `::label::` in Lua.
-    -- TSMethod             { } , -- Method calls and definitions.
-    -- TSNamespace          { } , -- Identifiers referring to modules and namespaces.
-    -- TSNone               { } , -- No highlighting (sets all highlight arguments to `NONE`). this group is used to clear certain ranges, for example, string interpolations. Don't change the values of this highlight group.
-    -- TSNumber             { } , -- Numeric literals that don't fit into other categories.
-    -- TSOperator           { } , -- Binary or unary operators: `+`, and also `->` and `*` in C.
-    -- TSParameter          { } , -- Parameters of a function.
-    -- TSParameterReference { } , -- References to parameters of a function.
-    -- TSPreProc            { } , -- Preprocessor #if, #else, #endif, etc.
-    -- TSProperty           { } , -- Same as `TSField`.
-    -- TSPunctDelimiter     { } , -- Punctuation delimiters: Periods, commas, semicolons, etc.
-    -- TSPunctBracket       { } , -- Brackets, braces, parentheses, etc.
-    -- TSPunctSpecial       { } , -- Special punctuation that doesn't fit into the previous categories.
-    -- TSRepeat             { } , -- Keywords related to loops: `for`, `while`, etc.
-    -- TSStorageClass       { } , -- Keywords that affect how a variable is stored: `static`, `comptime`, `extern`, etc.
-    -- TSString             { } , -- String literals.
-    -- TSStringRegex        { } , -- Regular expression literals.
-    -- TSStringEscape       { } , -- Escape characters within a string: `\n`, `\t`, etc.
-    -- TSStringSpecial      { } , -- Strings with special meaning that don't fit into the previous categories.
-    -- TSSymbol             { } , -- Identifiers referring to symbols or atoms.
-    -- TSTag                { } , -- Tags like HTML tag names.
-    -- TSTagAttribute       { } , -- HTML tag attributes.
-    -- TSTagDelimiter       { } , -- Tag delimiters like `<` `>` `/`.
-    -- TSText               { } , -- Non-structured text. Like text in a markup language.
-    -- TSStrong             { } , -- Text to be represented in bold.
-    -- TSEmphasis           { } , -- Text to be represented with emphasis.
-    -- TSUnderline          { } , -- Text to be represented with an underline.
-    -- TSStrike             { } , -- Strikethrough text.
-    -- TSTitle              { } , -- Text that is part of a title.
-    -- TSLiteral            { } , -- Literal or verbatim text.
-    -- TSURI                { } , -- URIs like hyperlinks or email addresses.
-    -- TSMath               { } , -- Math environments like LaTeX's `$ ... $`
-    -- TSTextReference      { } , -- Footnotes, text references, citations, etc.
-    -- TSEnvironment        { } , -- Text environments of markup languages.
-    -- TSEnvironmentName    { } , -- Text/string indicating the type of text environment. Like the name of a `\begin` block in LaTeX.
-    -- TSNote               { } , -- Text representation of an informational note.
-    -- TSWarning            { } , -- Text representation of a warning note.
-    -- TSDanger             { } , -- Text representation of a danger note.
-    -- TSType               { } , -- Type (and class) definitions and annotations.
-    -- TSTypeBuiltin        { } , -- Built-in types: `i32` in Rust.
-    -- TSVariable           { } , -- Variable names that don't fit into other categories.
-    -- TSVariableBuiltin    { } , -- Variable names defined by the language: `this` or `self` in Javascript.
-  }
+    -- See :h treesitter-highlight-groups, some groups may not be listed, submit a PR fix to lush-template!
+    -- the sym function below is from: https://github.com/rktjmp/lush.nvim/issues/109
+
+    -- sym('@text.literal')({}),        -- Comment
+    -- sym('@text.reference')({}),      -- Identifier
+    -- sym('@text.title')({}),          -- Title
+    -- sym('@text.uri')({}),            -- Underlined
+    -- sym('@text.underline')({}),      -- Underlined
+    -- sym('@text.todo')({}),           -- Todo
+    -- sym('@comment')({}),             -- Comment
+    -- sym('@punctuation')({}),         -- Delimiter
+    -- sym('@constant')({}),            -- Constant
+    -- sym('@constant.builtin')({}),    -- Special
+    -- sym('@constant.macro')({}),      -- Define
+    -- sym('@define')({}),              -- Define
+    -- sym('@macro')({}),               -- Macro
+    -- sym('@string')({}),              -- String
+    -- sym('@string.escape')({}),       -- SpecialChar
+    -- sym('@string.special')({}),      -- SpecialChar
+    -- sym('@character')({}),           -- Character
+    -- sym('@character.special')({}),   -- SpecialChar
+    -- sym('@number')({}),              -- Number
+    -- sym('@boolean')({}),             -- Boolean
+    -- sym('@float')({}),               -- Float
+    -- sym('@function')({}),            -- Function
+    -- sym('@function.builtin')({}),    -- Special
+    -- sym('@function.macro')({}),      -- Macro
+    -- sym('@parameter')({}),           -- Identifier
+    -- sym('@method')({}),              -- Function
+    -- sym('@field')({}),               -- Identifier
+    -- sym('@property')({}),            -- Identifier
+    -- sym('@constructor')({}),         -- Special
+    -- sym('@conditional')({}),         -- Conditional
+    -- sym('@repeat')({}),              -- Repeat
+    -- sym('@label')({}),               -- Label
+    -- sym('@operator')({}),            -- Operator
+    -- sym('@keyword')({}),             -- Keyword
+    -- sym('@exception')({}),           -- Exception
+    -- sym('@variable')({}),            -- Identifier
+    -- sym('@type')({}),                -- Type
+    -- sym('@type.definition')({}),     -- Typedef
+    -- sym('@storageclass')({}),        -- StorageClass
+    -- sym('@structure')({}),           -- Structure
+    -- sym('@namespace')({}),           -- Identifier
+    -- sym('@include')({}),             -- Include
+    -- sym('@preproc')({}),             -- PreProc
+    -- sym('@debug')({}),               -- Debug
+    -- sym('@tag')({}),                 -- Tag
+}
 end)
 
 -- Return our parsed theme for extension or use elsewhere.


### PR DESCRIPTION
I'm not sure if injecting `injected_functions` is ok to do in the template?